### PR TITLE
Fix parsing of list items with formatting

### DIFF
--- a/test/fixtures/list/07-with-inline-formatting.json
+++ b/test/fixtures/list/07-with-inline-formatting.json
@@ -1,0 +1,1 @@
+[{"insert":"milk"},{"insert":"\n","attributes":{"list":"ordered"}},{"insert":"cheese "},{"attributes":{"bold":true},"insert":"not gouda"},{"insert":"\n","attributes":{"list":"ordered"}},{"attributes":{"strike":true},"insert":"cigarette"},{"insert":" lollipop"},{"insert":"\n","attributes":{"list":"ordered"}}]

--- a/test/fixtures/list/07-with-inline-formatting.md
+++ b/test/fixtures/list/07-with-inline-formatting.md
@@ -1,0 +1,3 @@
+1. milk
+2. cheese **not gouda**
+3. ~~cigarette~~ lollipop


### PR DESCRIPTION
Fix inline formatting being converted as individual list items instead of a single group of text